### PR TITLE
Depend on linfa-clustering by path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["machine-learning", "linfa", "ai", "ml"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-linfa-clustering = "0.1"
+linfa-clustering = { path = "linfa-clustering", version = "0.1" }
 
 [dev-dependencies]
 ndarray = { version = "0.13" , features = ["rayon", "serde", "approx"]}


### PR DESCRIPTION
This makes no difference for people getting it from crates.io but simplifies local development greatly.

See [Specifying path dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies) in the Cargo Book.