### PR TITLE
A first draft of changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+Version 0.1.3 (_yet to be released_)
+===========================
+
+New algorithms 
+------------
+
+ - The `DBSCAN` clustering algorithm has been added to `linfa-clustering` ([#12](https://github.com/LukeMathWalker/linfa/pull/12) by [@xd009642])
+   
+Version 0.1.2 (2019-11-25)
+===========================
+
+New algorithms 
+------------
+
+ - First release of `linfa-clustering:v0.1.0` with the `KMeans` algorithm (by [@LukeMathWalker])
+ - First (real) release of `linfa`, re-exporting `linfa-clustering` (by [@LukeMathWalker])
+ 
+
+[@LukeMathWalker]: https://github.com/LukeMathWalker
+[@xd009642]: https://github.com/xd009642


### PR DESCRIPTION
It closes #14.

For the time being I guess it makes sense to keep a unified changelog (`linfa` level).
In the future we might want to split it further in a separate changelog for each sub-crate.